### PR TITLE
fix: prevent repeat ratings

### DIFF
--- a/app/components/ratingCreate.tsx
+++ b/app/components/ratingCreate.tsx
@@ -2,6 +2,7 @@ import { useSubmit } from "@remix-run/react";
 import { Restaurant } from "~/types";
 
 export function RatingCreate({
+  myRatings,
   tempRestaurant,
   setTempRestaurant,
   tempRating,
@@ -9,6 +10,7 @@ export function RatingCreate({
   setErrorMessage,
   setSelectedRestaurants,
 }: {
+  myRatings: Restaurant[];
   tempRestaurant: Restaurant | undefined;
   tempRating: number | null;
   setTempRestaurant: (value: Restaurant | undefined) => void;
@@ -26,10 +28,21 @@ export function RatingCreate({
     setErrorMessage("");
     const validRating = tempRating ?? 0;
 
+    const isAlreadyRated = myRatings.some(
+      (rating) => rating.place_id === prediction.place_id
+    );
+
+    if (isAlreadyRated) {
+      setTempRestaurant(undefined);
+      setErrorMessage("This restaurant has already been rated.");
+      return;
+    }
+
     if (tempRating === null || validRating < 1 || validRating > 5) {
       setErrorMessage("Please include a rating");
       return;
     }
+
     const newRestaurant: Restaurant = {
       ...prediction,
       name: prediction.main_text,

--- a/app/routes/newRating.tsx
+++ b/app/routes/newRating.tsx
@@ -11,14 +11,17 @@ import { RatingCreate } from "~/components/ratingCreate";
 import { RestaurantSearch } from "~/components/restaurantSearch";
 import { Restaurant } from "~/types";
 import { authenticator } from "~/utils/auth.server";
-import { createRestaurant } from "~/utils/restaurants.server";
+import { createRestaurant, getMyRestaurants } from "~/utils/restaurants.server";
 
 export const loader: LoaderFunction = async ({ request }) => {
   const user = await authenticator.isAuthenticated(request, {
     failureRedirect: "/login",
   });
 
-  return { user };
+  const myRatingsWithUser = await getMyRestaurants(user.id);
+  const myRatings = myRatingsWithUser.places;
+
+  return { user, myRatings };
 };
 
 export const action: ActionFunction = async ({ request }) => {
@@ -58,7 +61,7 @@ export const action: ActionFunction = async ({ request }) => {
 };
 
 export default function NewRating() {
-  const { user } = useLoaderData<typeof loader>();
+  const { user, myRatings } = useLoaderData<typeof loader>();
 
   const [tempRestaurant, setTempRestaurant] = useState<Restaurant | undefined>(
     undefined
@@ -106,6 +109,7 @@ export default function NewRating() {
             tempRating={tempRating}
             setTempRating={setTempRating}
             setErrorMessage={setErrorMessage}
+            myRatings={myRatings}
           />
           {errorMessage && (
             <div className="text-red-500 mt-2 ml-1">{errorMessage}</div>


### PR DESCRIPTION
Handling users trying to make a rating for a restaurant they've already rated. 
Sends the error message 
`This restaurant has already been rated.`

One potential issue identified is franchise restaurants that have the same or similar names (*Some restaurant Miami* & *Some restaurant Orlando*) can have separate ratings. This may not be an issue, different locations can have better/worse service, different styles etc.