### PR TITLE
fix: navbar covered the screen on mobile, this fixes that

### DIFF
--- a/app/components/navBar.tsx
+++ b/app/components/navBar.tsx
@@ -9,7 +9,7 @@ export function NavBar() {
   const currentPath = location.pathname;
 
   return (
-    <div className="fixed top-0 left-0 h-screen w-16 m-0 flex flex-col bg-gray-900 text-white shadow-lg">
+    <div className="fixed bottom-0 left-0 w-full h-16 flex flex-row bg-gray-900 text-white shadow-lg sm:top-0 sm:left-0 sm:h-screen sm:w-16 sm:flex-col">
       <NavBarIcon
         icon={<FaHome size="28" />}
         onClick={() => navigate("/home")}


### PR DESCRIPTION
# fix: navbar covered the screen on mobile, this fixes that

Before: 
<img width="532" alt="Mobile view before" src="https://github.com/user-attachments/assets/b4161bb6-7045-4b94-a53b-dadb70072085">

After:
<img width="478" alt="Mobile view after" src="https://github.com/user-attachments/assets/496d89d9-44b7-4bc5-b894-703dfe3b1696">
